### PR TITLE
Update incompatibility types in BC template

### DIFF
--- a/.github/ISSUE_TEMPLATE/breaking-change.yaml
+++ b/.github/ISSUE_TEMPLATE/breaking-change.yaml
@@ -20,16 +20,7 @@ body:
       label: Version
       description: What version of .NET introduced the breaking change?
       options:
-        - .NET 7 Preview 1
-        - .NET 7 Preview 2
-        - .NET 7 Preview 3
-        - .NET 7 Preview 4
-        - .NET 7 Preview 5
-        - .NET 7 Preview 6
-        - .NET 7 Preview 7
-        - .NET 7 RC 1
-        - .NET 7 RC 2
-        - .NET 7 GA
+        - .NET 7
         - .NET 8 Preview 1
         - .NET 8 Preview 2
         - .NET 8 Preview 3
@@ -52,13 +43,12 @@ body:
       required: true
   - type: checkboxes
     id: change-type
-    attributes:
       label: Type of breaking change
-      description: This information will be used to label the issue appropriately.
+      description: This information will be used to label the issue appropriately. [(How do I decide?)](https://learn.microsoft.com/dotnet/core/compatibility/categories)
       options:
-        - label: "**Binary incompatible**: Existing binaries may encounter a breaking change in behavior, such as failure to load/execute or different run-time behavior."
-        - label: "**Source incompatible**: Source code may encounter a breaking change in behavior when targeting the new runtime/component/SDK, such as compile errors or different run-time behavior."
-        - label: "**Behavioral change**: Existing code and binaries may experience different run-time behavior."
+        - label: "**Binary incompatible**: Existing binaries may encounter a breaking change in behavior, such as failure to load or execute, and if so, require recompilation."
+        - label:  "**Source incompatible**: When recompiled using the new SDK or component or to target the new runtime, existing source code may require source changes to compile successfully."
+        - label:  "**Behavioral change**: Existing binaries may behave differently at run time."
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
I updated the breaking change template to match dotnet/docs. Feel free to close if you don't like these definitions, however.